### PR TITLE
load signing keys from keycloak only once for get_username in DE5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
         "requests[security]",
         "PyJWT",
         'cryptography;python_version>="3.7"',
-        'cryptography<3.4;python_version<"3.7"'
+        'cryptography<3.4;python_version<"3.7"',
+        "retrying==1.3.3",
     ],
     python_requires=">=3.6",
     url="https://plotly.com/dash",
@@ -42,5 +43,5 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-    ]
+    ],
 )


### PR DESCRIPTION
This PR resolves https://github.com/plotly/dekn/issues/6812 by preventing auth.get_username() from making any requests to keycloak. The signing keys are loaded when the app starts and since [they don't change very often](https://github.com/plotly/dekn/issues/6812#issuecomment-1915664117), I think it should be fine.