### PR TITLE
Fix CI error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dep-{{ checksum ".circleci/config.yml" }}-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
+          key: dep-{{ checksum ".circleci/config.yml" }}-{{ checksum "dash_enterprise_auth/version.py" }}-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
       - run:
           name: Install requirements
           command: |
@@ -21,7 +21,7 @@ jobs:
             python -m pip install --upgrade pip
             pip install -r requirements.txt
       - save_cache:
-          key: dep-{{ checksum ".circleci/config.yml" }}-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
+          key: dep-{{ checksum ".circleci/config.yml" }}-{{ checksum "dash_enterprise_auth/version.py" }}-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - venv
       - run:


### PR DESCRIPTION
Noticed some CI failures where it was unable to find `python`. 

https://app.circleci.com/pipelines/github/plotly/dash-enterprise-auth/79/workflows/af7ea7e6-f098-4bd1-b576-38b45b525f38/jobs/113

In this PR we just add the version to the checksum to clear the cache. 