### PR TITLE
Update Flask and Werkzeug version constraints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ setup(
     ],
     install_requires=[
         "dash",
-        "Flask>=1.0.4,<3.1",
-        "Werkzeug<3.1",
+        "Flask>=1.0.4,<3.2",
+        "Werkzeug<3.2",
         "requests[security]",
         "PyJWT",
         'cryptography;python_version>="3.7"',


### PR DESCRIPTION
Bump upper bound to 3.2:
- For parity with dash>=3.1.0: https://github.com/plotly/dash/commit/558ab0c60d83417f974c8c1e355a1906cf5497ee
- To fix werkzeug's vulnerability: https://github.com/plotly/dash-enterprise-auth/issues/55